### PR TITLE
Mismatching variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var jasmineWebpackPlugin = require('jasmine-webpack-plugin');
 module.exports = {
   entry: ['specRoot.js'],
   // ... more configuration
-  plugins: [new JasmineWebpackPlugin()]
+  plugins: [new jasmineWebpackPlugin()]
 };
 ```
 


### PR DESCRIPTION
Trying to use the sample code from the README causes an error as a variable name is once called with a capital letter, and once without.
