### PR TITLE
Support for adding external js files to _specRunner.html

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,14 @@ var jasmineBootFiles = resolveJasmineFiles(jasmineBootDir, jasmineFiles.bootFile
 
 function JasmineWebpackPlugin(options) {
   options = options || {};
-
+  var externalJsFiles = options.externalJsFiles || [];
   return new HtmlWebpackPlugin({
     inject: true,
     filename: options.filename || '_specRunner.html',
     templateContent: template,
     jasmineJsFiles: jasmineJsFiles.concat(jasmineBootFiles),
-    jasmineCssFiles: jasmineCssFiles
+    jasmineCssFiles: jasmineCssFiles,
+    externalJsFiles: externalJsFiles
   });
 }
 

--- a/specRunnerTemplate.js
+++ b/specRunnerTemplate.js
@@ -10,6 +10,9 @@ var template = '<!DOCTYPE html>' +
     '{% for (var i = 0; i < o.htmlWebpackPlugin.options.jasmineJsFiles.length; i++) { %}' +
       '<script src="{%=o.htmlWebpackPlugin.options.jasmineJsFiles[i]%}"></script>' +
     '{% } %}' +
+    '{% for (var i = 0; i < o.htmlWebpackPlugin.options.externalJsFiles.length; i++) { %}' +
+    '<script src="{%=o.htmlWebpackPlugin.options.externalJsFiles[i]%}"></script>' +
+    '{% } %}' +
   '</head>' +
   '<body>' +
   '</body>' +


### PR DESCRIPTION
Sometimes you may need to add external javascript dependencies. This allows you to add external js files to _specRunner.html. They will be added as <script> tags in the html head. Use the config.externalJsFiles option.