### PR TITLE
Small typo correction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In your webpack configuration:
 ```javascript
 // webpack-test.config.js
 
-var jasmineWebpackPlugin = require('jasmine-webpack-plugin');
+var JasmineWebpackPlugin = require('jasmine-webpack-plugin');
 
 module.exports = {
   entry: ['specRoot.js'],


### PR DESCRIPTION
The example config doesn't work as is (for other reasons, but also for this one) since the plugin is imported as jasmineWebpackPlugin, rather than JasmineWebpackPlugin.